### PR TITLE
Make title changable for live by setting `title` in search param

### DIFF
--- a/client/src/components/bar.svelte
+++ b/client/src/components/bar.svelte
@@ -3,6 +3,7 @@
 
   let clazz = ""; 
   export { clazz as class };
+  export let title = "Weekly CCV Goal"
   export let current = 11;
   export let target = 24;
   function setCounter(current: number, target: number) {
@@ -83,7 +84,7 @@
     <rect class="hatch-mask" width="100%" height="100%" mask="url(#mymask)" />
     <rect class="bg-mask" width="100%" height="100%" />
     <rect class="target-point" x="0" width="3" height="100%" />
-    <text class="text" x="1%" y="80%">Weekly CCV Goal </text>
+    <text class="text" x="1%" y="80%">{title}</text>
     <text class="text count" x="99%" y="80%"
       >{Math.floor(current)}/{Math.floor(target)}</text
     >

--- a/client/src/pages/livePage.svelte
+++ b/client/src/pages/livePage.svelte
@@ -14,6 +14,8 @@
     previousCount = last;
     currentCount = current;
   };
+  const t=(new URL(window.location.href).searchParams.get("title")) || "Weekly CCV goal"
+
   // $: Targetpercentage = 80
   onMount(async () => {
     const data = await fetchCurrentDateMetric(account);
@@ -30,5 +32,5 @@
 </script>
 
 <div class="obs-overrideable">
-  <Bar current={currentCount} target={previousCount} />
+  <Bar current={currentCount} target={previousCount} title={t}  />
 </div>


### PR DESCRIPTION
During first KrazeyHazey stream, Idea came up in chat to change "Weekly CCV goal" to "Concurrent sausages"

This PR, Adds an ability to change the bar title by setting `title` in query string (see:
https://concurrent-viewers-blaveiah8-crasty01.vercel.app/live/krazeyhazey?title=Concurrent%20sausages)